### PR TITLE
Fix typo in comment

### DIFF
--- a/Two motion sensors.js
+++ b/Two motion sensors.js
@@ -1,6 +1,6 @@
 / This script is for using 2 (two) Shelly BLU motion sensors triggering a Shelly 1PM mini Gen3 relais.
 / The difference to the original script from the Shelly Library called "BLE in Scripting - Shelly BLU
-/ Motion script actions" is that the relais turnes off only when both motion sensors report "no motion".
+/ Motion script actions" is that the relais turns off only when both motion sensors report "no motion".
 / In the original script one motion sensor reporting "no motion" turned the relais off. 
 / The part after "STOP CHANGE HERE" is identical to the original script
 / (https://github.com/ALLTERCO/shelly-script-examples/blob/main/ble-shelly-motion.js)! 


### PR DESCRIPTION
## Summary
- correct 'turnes' typo in `Two motion sensors.js`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68400c9c48c88332a3ecf09faf0c6cd4